### PR TITLE
Add `jupyter` and `toml` file types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           git config user.name 'Github Actions'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff check --force-exclude' --id ruff --types-or python --types-or pyi --require-serial --description "Run 'ruff' for extremely fast Python linting" .
+      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff check --force-exclude' --id ruff --types-or python --types-or pyi --types-or jupyter --require-serial --description "Run 'ruff' for extremely fast Python linting" .
 
       - run: git push origin HEAD:refs/heads/main --tags
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           git config user.name 'Github Actions'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff check --force-exclude' --id ruff --types-or python --types-or pyi --types-or jupyter --require-serial --description "Run 'ruff' for extremely fast Python linting" .
+      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff check --force-exclude' --id ruff --types-or python --types-or pyi --types-or jupyter  --types-or toml --require-serial --description "Run 'ruff' for extremely fast Python linting" .
 
       - run: git push origin HEAD:refs/heads/main --tags
 


### PR DESCRIPTION
Fixes #43

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add `jupyter` to the file types that ruff pre-commit hook runs on

## Test Plan

This is what pre-commit uses to identify ".ipynb" files. See https://github.com/pre-commit/identify/blob/dc75a76b7fd7093a7a1d4159d6741884343af694/identify/extensions.py#L100
Also black does this https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml