### PR TITLE
Add alpha formatter support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,20 @@
--   id: ruff
-    name: ruff
-    description: "Run 'ruff' for extremely fast Python linting"
-    entry: ruff check --force-exclude
-    language: python
-    'types_or': [python, pyi]
-    args: []
-    require_serial: true
-    additional_dependencies: []
-    minimum_pre_commit_version: '2.9.2'
+- id: ruff
+  name: ruff
+  description: "Run 'ruff' for extremely fast Python linting"
+  entry: ruff check --force-exclude
+  language: python
+  "types_or": [python, pyi]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"
+- id: ruff-format
+  name: ruff-format
+  description: "Run 'ruff format' for extremely fast Python formatting"
+  entry: ruff format --check
+  language: python
+  "types_or": [python, pyi]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,7 +11,7 @@
 - id: ruff-format
   name: ruff-format
   description: "Run 'ruff format' for extremely fast Python formatting"
-  entry: ruff format --check --force-exclude
+  entry: ruff format --force-exclude
   language: python
   "types_or": [python, pyi]
   args: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,7 +11,7 @@
 - id: ruff-format
   name: ruff-format
   description: "Run 'ruff format' for extremely fast Python formatting"
-  entry: ruff format --check
+  entry: ruff format --check --force-exclude
   language: python
   "types_or": [python, pyi]
   args: []

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ reformatting.
     - id: ruff-format
 ```
 
-To check formatting with changing files,  use `--check`:
+To check formatting without changing files, use `--check`:
 
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ _unless_ you enable autofix, in which case, Ruff's pre-commit hook should run _b
 and other formatting tools, as Ruff's autofix behavior can output code changes that require
 reformatting.
 
+### Using Ruff's formatter (unstable)
+
+Ruff's formatter is in Alpha, but can used with pre-commit by adding the `ruff-format` hook:
+
+```yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.289
+  hooks:
+    - id: ruff-format
+```
+
+To check formatting with changing files,  use `--check`:
+
+```yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.0.289
+  hooks:
+    - id: ruff-format
+      args: [--check]
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ reformatting.
 
 ### Using Ruff's formatter (unstable)
 
-Ruff's formatter is in Alpha, but can used with pre-commit by adding the `ruff-format` hook:
+[Ruff's formatter](https://github.com/astral-sh/ruff/blob/main/crates/ruff_python_formatter/README.md) is in Alpha, but can used with pre-commit by adding the `ruff-format` hook:
 
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Tested with `pre-commit try-repo . --all-files`

```
❯ pre-commit try-repo . --all-files
[INFO] Initializing environment for ..
===============================================================================
Using config:
===============================================================================
repos:
-   repo: .
    rev: 6bd1079860e4a235eb49e2d56857d43748f7a389
    hooks:
    -   id: ruff
    -   id: ruff-format
===============================================================================
[INFO] Installing environment for ..
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
ruff.....................................................................Passed
ruff-format..............................................................Failed
- hook id: ruff-format
- exit code: 1

warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
1 file would be reformatted, 1 file left unchanged

```

And a configuration pointing to this work

```yaml
repos:
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: 2eeece5511efd959268030fa80ece7a2d54411b5
    hooks:
      - id: ruff
      - id: "ruff-format"
        args: [--check]
```
```
❯ pre-commit run --all-files
[INFO] Installing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
ruff.....................................................................Passed
ruff-format..............................................................Passed
```