### PR TITLE
Restore `ruff-format` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,20 @@
--   id: ruff
-    name: ruff
-    description: "Run 'ruff' for extremely fast Python linting"
-    entry: ruff check --force-exclude
-    language: python
-    'types_or': [python, pyi]
-    args: []
-    require_serial: true
-    additional_dependencies: []
-    minimum_pre_commit_version: '2.9.2'
+- id: ruff
+  name: ruff
+  description: "Run 'ruff' for extremely fast Python linting"
+  entry: ruff check --force-exclude
+  language: python
+  "types_or": [python, pyi]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"
+- id: ruff-format
+  name: ruff-format
+  description: "Run 'ruff format' for extremely fast Python formatting"
+  entry: ruff format --force-exclude
+  language: python
+  "types_or": [python, pyi]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"


### PR DESCRIPTION
Deleted by automation in https://github.com/astral-sh/ruff-pre-commit/commit/55147f81dc631fbb8d3d19be5a8caceff34d7ae7
