### PR TITLE
docs: remove alpha designation on ruff-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ reformatting.
 
 ### Using Ruff's formatter (unstable)
 
-[Ruff's formatter](https://github.com/astral-sh/ruff/blob/main/crates/ruff_python_formatter/README.md) is in Alpha, but can used with pre-commit by adding the `ruff-format` hook:
+[Ruff's formatter](https://docs.astral.sh/ruff/formatter) can used with pre-commit by adding the `ruff-format` hook:
 
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
I think this was old?