### PR TITLE
add instruction on how to force ruff hooks to honor excluded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ To enable lint fixes, add the `--fix` argument to the lint hook:
     - id: ruff-format
 ```
 
+Please note that `pre-commit` passes all changed files to its hooks explicitly.
+`ruff` will also lint/format *any paths passed in directly*, even if they're excluded in your config file (e.g. `pyproject.toml`).
+Therefore, to force `ruff` honor your [exclude](https://docs.astral.sh/ruff/settings/#exclude)/[extend-exclude](https://docs.astral.sh/ruff/settings/#extend-exclude)
+setting, add [--force-exclude](https://docs.astral.sh/ruff/settings/#force-exclude) argument to the hooks:
+
+```yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.6
+  hooks:
+    - id: ruff
+      args: [ --fix, --force-exclude ]
+    - id: ruff-format
+      args: [ --force-exclude ]
+```
+
 To run the hooks over Jupyter Notebooks too, add `jupyter` to the list of allowed filetypes:
 
 ```yaml


### PR DESCRIPTION
Hi Charlie and the team! 👋🏼

Absolutely in awe, without exaggeration, of what you've built and how it's simplified the lint-/formatting workflows in Python. I read the original [project announcement](https://notes.crmarsh.com/python-tooling-could-be-much-much-faster) and I wrote it down in my notes as a source of inspiration for turning a curious reader into a fan in as concise and effective of a way as possible.

Thank you very much 🙌🏼

---

#### What's the purpose of the change? What does it do, and why?

The purpose is to prevent `ruff` pre-commit hooks lint-/formatting files I've already excluded in `pyproject.toml`.

I thought it's necessary because pre-commit lint-/formatting files I've **explicitly ignored** is rather confusing. Given, of course, not knowing `ruff`'s default behavior of lint-/formatting files passed in directly regardless of `exclude`/`extend-exclude` settings (unless `--force-exclude` is set).

#### How was it tested?

More like reproduction steps:

- Given the following `pyproject.toml`
```toml
[tool.ruff]
extend-exclude = ["project/settings.py"]
```
- Running
```bash
ruff check .
# returns nothing, all good
```

- Then, thinking "all good", after a few days, I return to `project/settings.py` and make an edit and commit. pre-commit fails and I'd be surprised as to why:
```
ruff formatter...........................................................Failed
- hook id: ruff-format
- files were modified by this hook

1 file reformatted
```

---

#### Suggestion
If I may give my 2 cents: I think `ruff` ignoring `exclude`/`extend-exclude` unless `force-exclude` is set is confusing and counter-intuitive. I think many folks, myself included, consider `pyproject.toml` the «source of truth» for their config and expect the tools to honor the `exclude` settings specified there. We can always override those in the cli using `--force-format` (made up flag) or similar flags if we want to bypass the «source of truth».

---

Thanks again 😊