### PR TITLE
Add uv support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,3 +19,13 @@
   require_serial: true
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"
+
+- id: pip-compile
+  name: pip-compile
+  description: Automatically compile requirements.
+  entry: uv pip compile
+  language: python
+  files: ^requirements\.(in|txt)$
+  pass_filenames: false
+  additional_dependencies: ['uv']
+  minimum_pre_commit_version: "2.9.2"


### PR DESCRIPTION
## Summary

Add support for UV as a pre-commit hook (drop-in replacement for https://github.com/jazzband/pip-tools

## Test Plan

Locally and via this PR as a [CI run](https://github.com/matmair/InvenTree/actions/runs/7923292223/job/21632709431) on GitHub.

There is still a large diff because of https://github.com/astral-sh/uv/issues/1343, once that is resolved this should be 2 line change in the pre-commit for a considerable speedup.