### PR TITLE
Update README.md to include force-exclude warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ When running without `--fix`, Ruff's formatter hook can be placed before or afte
 `ruff format` should never introduce new lint errors, so it's safe to run Ruff's format hook _after_
 `ruff check --fix`.)
 
+> [!IMPORTANT]  
+> By default this hook runs with the `--force-exclude` argument. This means that any excludes
+> defined in `pyproject.toml` or `ruff.toml` will be excluded even when explicitly passed in via the
+> CI runner,  This can cause differences between how `ruff check` behaves locally and inside
+> of CI. See the documentation for [exclude](https://docs.astral.sh/ruff/settings/#exclude) and
+> [force-exclude](https://docs.astral.sh/ruff/settings/#force-exclude) for further details.
+
 ## License
 
 MIT


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Updates README.md to include a warning about the default choice of `--force-exclude` being used by the github action. This warning includes links to the documentation for these settings. Addresses #69

## Test Plan

<!-- How was it tested? -->
N/A - this is an update to `README.md`.
