### PR TITLE
feat(workflow): auto release on tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Releases
+
+on:
+  push:
+    tags:
+      - 'v?[0-9]+.[0-9]+.[0-9]*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes "See: https://github.com/astral-sh/ruff/releases/tag/$TAG_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mirror.py
+++ b/mirror.py
@@ -1,9 +1,9 @@
 import re
 import subprocess
+import tomllib
 import typing
 from pathlib import Path
 
-import tomllib
 import urllib3
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -20,14 +20,14 @@ def main():
     for version in target_versions:
         paths = process_version(version)
         if subprocess.check_output(["git", "status", "-s"]).strip():
-            subprocess.run(["git", "add", *paths])
-            subprocess.run(["git", "commit", "-m", f"Mirror: {version}"])
-            subprocess.run(["git", "tag", f"v{version}"])
+            subprocess.run(["git", "add", *paths], check=True)
+            subprocess.run(["git", "commit", "-m", f"Mirror: {version}"], check=True)
+            subprocess.run(["git", "tag", f"v{version}"], check=True)
         else:
             print(f"No change v{version}")
 
 
-def get_all_versions() -> typing.List[Version]:
+def get_all_versions() -> list[Version]:
     response = urllib3.request("GET", "https://pypi.org/pypi/ruff/json")
     if response.status != 200:
         raise RuntimeError("Failed to fetch versions from pypi")


### PR DESCRIPTION
## Summary

Add a GitHub workflow for creating a new release, automatically, when a new tag is created.

This solves #78. The code is very similar to the changes added in https://github.com/astral-sh/uv-pre-commit/pull/6

The primary difference, is that the URL points to ruff and this one checks for if the tag starts with a `v`, but it is optional. This lets you change ruff versions to not have a `v` in the future. Although the `mirror.py` will need to be updated. 
Speaking of updates to `mirror.py`, I ran `ruff` on it and updated the `subprocess` to raise an error on failure. 

## Test Plan

Locally tested.
