### PR TITLE
fix: correct release notes link

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           echo $TAG_NAME
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes "See: https://github.com/astral-sh/uv/releases/tag/$TAG_NAME" \
+            --notes "See: https://github.com/astral-sh/ruff/releases/tag/$TAG_NAME" \
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

I originally tested this functionality in `uv-pre-commit`. And that is why when moving it over, I ended up copying the URL for that release. I am sorry for all the broken code I have introduced. I feel so bad. I am at least glad I realized before a new `ruff` release came out. 
