### PR TITLE
add ruff-docs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,3 +19,14 @@
   require_serial: true
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"
+
+- id: ruff-docs
+  name: ruff-docs
+  description: "Run 'ruff' to format docstrings, and codesnippets in your docs"
+  entry: ruff format --force-exclude --config format.docstring-code-format=true
+  language: python
+  types_or: [python, pyi, markdown, rst]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ When running without `--fix`, Ruff's formatter hook can be placed before or afte
 `ruff format` should never introduce new lint errors, so it's safe to run Ruff's format hook _after_
 `ruff check --fix`.)
 
+Since ruff format can be [used to format documentation](https://docs.astral.sh/ruff/formatter/#docstring-formatting) (codesnippets in your docs, docstrings in your code) you can use it via `ruff-docs`. You can optionally set a line-length:
+
+
+```yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.4.5
+  hooks:
+    # Run the linter.
+    - id: ruff
+      types_or: [ python, pyi, jupyter ]
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]
+    # Format docs(trings)
+    - id: ruff-docs
+      types_or: [ python, pyi, jupyter, markdown, rst ]
+      args: [ --config, format.docstring-code-line-length=72 ]
+```
+
+
 ## License
 
 ruff-pre-commit is licensed under either of


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Since ruff can fix docs(trings) it can replace something like blacken-docs too, that way everything is consistent.  

## Test Plan

I forked the repo, added the new hook-id, recreated the current release-tag and used it in a dedicated repo in a pre-commit file and it worked. 
