### PR TITLE
Remove "v" from the Ruff version number in link to release notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           echo $TAG_NAME
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes "See: https://github.com/astral-sh/ruff/releases/tag/$TAG_NAME" \
+            --notes "See: https://github.com/astral-sh/ruff/releases/tag/${TAG_NAME/v}" \
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Starting with version 0.5.0 of Ruff, the release/tag name doesn't have a leading "v". This has broken the link to the release notes that get added to the release notes for the pre-commit hook.

This fixes it by stripping any "v" from the version number string.

See #91.

## Test Plan

Tested in a bash shell:
```bash
bash-5.2$ TAG_NAME=v0.5.0
bash-5.2$ echo ${TAG_NAME/v}
0.5.0
```

Will otherwise have to be tested on the next Ruff release.