### PR TITLE
feat: remove the `v` from version, to match ruff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           echo $TAG_NAME
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes "See: https://github.com/astral-sh/ruff/releases/tag/${TAG_NAME/v}" \
+            --notes "See: https://github.com/astral-sh/ruff/releases/tag/${TAG_NAME}" \
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mirror.py
+++ b/mirror.py
@@ -22,9 +22,9 @@ def main():
         if subprocess.check_output(["git", "status", "-s"]).strip():
             subprocess.run(["git", "add", *paths], check=True)
             subprocess.run(["git", "commit", "-m", f"Mirror: {version}"], check=True)
-            subprocess.run(["git", "tag", f"v{version}"], check=True)
+            subprocess.run(["git", "tag", f"{version}"], check=True)
         else:
-            print(f"No change v{version}")
+            print(f"No change {version}")
 
 
 def get_all_versions() -> list[Version]:
@@ -54,7 +54,7 @@ def process_version(version: Version) -> typing.Sequence[str]:
         return re.sub(r'"ruff==.*"', f'"ruff=={version}"', content)
 
     def replace_readme_md(content: str) -> str:
-        content = re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{version}", content)
+        content = re.sub(r"rev: \d+\.\d+\.\d+", f"rev: {version}", content)
         return re.sub(r"/ruff/\d+\.\d+\.\d+\.svg", f"/ruff/{version}.svg", content)
 
     paths = {


### PR DESCRIPTION
Since version `0.5`, ruff has dropped the `v` in its version. This mirrors that.

As mentioned and done in https://github.com/astral-sh/uv-pre-commit/issues/5, `ruff` no longer has `v` in its version. This PR removes it. This is an in between commit while I wait for approval of a bigger restructure. 

This also undos #92. As mentioned there, the reason the link was wrong, was because of the de-sync between version semantics. 

> [!IMPORTANT]
> After merging, manually create a new tag and version.