### PR TITLE
Add and prefer the `ruff-check` pre-commit ID

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
-- id: ruff
-  name: ruff
-  description: "Run 'ruff' for extremely fast Python linting"
+- id: ruff-check
+  name: ruff check
+  description: "Run 'ruff check' for extremely fast Python linting"
   entry: ruff check --force-exclude
   language: python
   types_or: [python, pyi, jupyter]
@@ -10,9 +10,21 @@
   minimum_pre_commit_version: "2.9.2"
 
 - id: ruff-format
-  name: ruff-format
+  name: ruff format
   description: "Run 'ruff format' for extremely fast Python formatting"
   entry: ruff format --force-exclude
+  language: python
+  types_or: [python, pyi, jupyter]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"
+
+# Legacy alias
+- id: ruff
+  name: ruff (legacy alias)
+  description: "Run 'ruff check' for extremely fast Python linting"
+  entry: ruff check --force-exclude
   language: python
   types_or: [python, pyi, jupyter]
   args: []

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repos:
   rev: v0.11.8
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
     # Run the formatter.
     - id: ruff-format
 ```
@@ -37,7 +37,7 @@ repos:
   rev: v0.11.8
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
@@ -52,7 +52,7 @@ repos:
   rev: v0.11.8
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       types_or: [ python, pyi ]
       args: [ --fix ]
     # Run the formatter.


### PR DESCRIPTION
## Summary

Towards #123. Introduces the `ruff-check` pre-commit hook ID, updates documentation to prefer it, but retains the `ruff` ID for compatibility.

cc @dhruvmanila @zanieb 

A
