### PR TITLE
chore(ci): add dependabot, fix small CI lint issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
   repository_dispatch:
     types: [pypi_release]
 
+permissions: {}
+
 jobs:
   build:
     name: main
@@ -16,10 +18,12 @@ jobs:
       - if: ${{ startsWith(github.event_name, 'repository_dispatch') }}
         run: sleep 30
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
 
       - name: set git config
         run: |


### PR DESCRIPTION
## Summary

Part of my ongoing burndown of CI lint findings from zizmor.

Key changes: I've addressed some small lint findings (very small in this case) and have added a Dependabot config that'll keep the actions up-to-date (they were a bit stale).

## Test Plan

See what happens in CI 🙂 -- this should have no functional changes.