### PR TITLE
fix(ci): enable persist-credentials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          persist-credentials: true
+          persist-credentials: true # needed to push commits below
 
       - name: Install uv
         uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0


### PR DESCRIPTION
## Summary

Enables `persist-credentials` explicitly, since this workflow needs to push commits.

See https://github.com/astral-sh/uv-pre-commit/pull/57#issuecomment-3199589061 for the failure mode here.

## Test Plan

Not easy to test, since this behavior only appears on "release" flows.